### PR TITLE
added -i / -o option to set getc / putc addresses

### DIFF
--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -45,8 +45,8 @@ class Monitor(cmd.Cmd):
     def __init__(self, mpu_type=NMOS6502, completekey='tab', stdin=None,
                  stdout=None, argv=None):
         self.mpu_type = mpu_type
-	self.putc_addr = 0xF001
-	self.getc_addr = 0xF004
+        self.putc_addr = 0xF001
+        self.getc_addr = 0xF004
         if argv is None:
             argv = sys.argv
         self._breakpoints = []
@@ -69,11 +69,11 @@ class Monitor(cmd.Cmd):
 
         for opt, value in options:
 
-	    if opt in ('-i', '--input'):
-		self.getc_addr = int(value.upper(), 16)
+            if opt in ('-i', '--input'):
+                self.getc_addr = int(value.upper(), 16)
 
-	    if opt in ('-o', '--output'):
-		self.putc_addr = int(value.upper(), 16)
+            if opt in ('-o', '--output'):
+                self.putc_addr = int(value.upper(), 16)
 
             if opt in ('-l', '--load'):
                 cmd = "load %s" % value


### PR DESCRIPTION
Sometimes it's useful to set the getc and putc addresses to different values. Added to new commandline parameters (-i / -o) to set the addresses during startup. 
The default is still 0xF001 and 0xF004. There should be no impact if the parameters are not used. 

I figured out, that in the current version of the origin master the order of the parameters is important, because any settings are directly changed in the emulated machine. If the CPU type is not set before a ROM image is loaded ( -r rom.img -m 65c02 will not work, if rom.img has 65C02 code) you might have a problem. 
Maybe this should be changed in a future release by first parsing and saving all parameters and then set everything in one step in the correct order. 