### PR TITLE
Fixing order dependencies of commandline args

### DIFF
--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -103,10 +103,6 @@ class Monitor(cmd.Cmd):
                 self._usage()
                 self._exit(1)
 
-        if flag_load == True:
-            cmd = "load %s" % load_value
-            self.onecmd(cmd)
-
         if (flag_mpu == True) or (flag_rom == True):
             if mpu_value == "":
                 mpu_value = "6502"
@@ -117,6 +113,10 @@ class Monitor(cmd.Cmd):
                 self._output(msg % ', '.join(mpus))
                 sys.exit(1)
             cmd = "mpu %s" % mpu_value
+            self.onecmd(cmd)
+
+        if flag_load == True:
+            cmd = "load %s" % load_value
             self.onecmd(cmd)
 
         if flag_goto == True:

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -107,7 +107,9 @@ class Monitor(cmd.Cmd):
             cmd = "load %s" % load_value
             self.onecmd(cmd)
 
-        if flag_mpu == True:
+        if (flag_mpu == True) or (flag_rom == True):
+            if mpu_value == "":
+                mpu_value = "6502"
             if self._get_mpu(mpu_value) is None:
                 mpus = list(self.Microprocessors.keys())
                 mpus.sort()

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -107,15 +107,15 @@ class Monitor(cmd.Cmd):
             cmd = "load %s" % load_value
             self.onecmd(cmd)
 
-        # mpu should set everytime (default ist 6502)
-        if self._get_mpu(mpu_value) is None:
-            mpus = list(self.Microprocessors.keys())
-            mpus.sort()
-            msg = "Fatal: no such MPU. Available MPUs: %s"
-            self._output(msg % ', '.join(mpus))
-            sys.exit(1)
-        cmd = "mpu %s" % mpu_value
-        self.onecmd(cmd)
+        if flag_mpu == True:
+            if self._get_mpu(mpu_value) is None:
+                mpus = list(self.Microprocessors.keys())
+                mpus.sort()
+                msg = "Fatal: no such MPU. Available MPUs: %s"
+                self._output(msg % ', '.join(mpus))
+                sys.exit(1)
+            cmd = "mpu %s" % mpu_value
+            self.onecmd(cmd)
 
         if flag_goto == True:
             cmd = "goto %s" % goto_value


### PR DESCRIPTION
All commands are now parsed without executing anything in the emulated machine. Only settings like getc/putc are done directly. 
Commandline arguments can now be given in any order without problems.
It also fixes a bug when giving a rom image without setting an mpu leads to an error. 