### PR TITLE
Rewrite of itoa() in utils/conversions.py

### DIFF
--- a/py65/utils/conversions.py
+++ b/py65/utils/conversions.py
@@ -1,20 +1,19 @@
-
-
 def itoa(num, base=10):
-    """ Convert a decimal number to its equivalent in another base.
-    This is essentially the inverse of int(num, base).
+    """Convert a decimal number to its equivalent in base 2 or 16; base 10
+    is silently passed through. Other bases raise a ValueError. Returns a
+    string with hex digits lowercase.
     """
-    negative = num < 0
-    if negative:
-        num = -num
-    digits = []
-    while num > 0:
-        num, last_digit = divmod(num, base)
-        digits.append('0123456789abcdefghijklmnopqrstuvwxyz'[last_digit])
-    if negative:
-        digits.append('-')
-    digits.reverse()
-    return ''.join(digits)
+    if base == 2:
+        newnum = "{0:b}".format(num)
+    elif base == 16:
+        newnum = "{0:x}".format(num)
+    elif base == 10:
+        newnum = "{0}".format(num)
+    else:
+        msg = 'Could not convert number "{0}" to base "{1}"'.format(num, base)
+        raise ValueError(msg)
+
+    return newnum
 
 
 def convert_to_bin(bcd):


### PR DESCRIPTION
The current version of conversions.py will convert a number to any base, though py65 only uses binary, hex, and decimal (see "Number Systems" in the docs). Also, this routine will not produce a warning if for some reason the base is given as, say, 17. 

The changes replace this code with str.format() commands, making use of the faster built-in functions, simplifying the code to a single if-test, and throw a ValueError if the base is not binary, hex, or decimal. Hexadecimal characters are lowercase as in the original routine.

The changes pass the included tests called as

     python3 -m unittest py65/tests/utils/test_conversions.py

with Python 3.5.2 on Ubuntu 16.04.3 LTS. As I am unsure of the procedure here, I'd be grateful for further testing by somebody who, uh, actually knows what they are doing.