### PR TITLE
fixup command line setting of mpu in monitor.py

### DIFF
--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -105,7 +105,7 @@ class Monitor(cmd.Cmd):
                 msg = "Fatal: no such MPU. Available MPUs: %s"
                 self._output(msg % ', '.join(mpus))
                 sys.exit(1)
-             self.mpu_type = self._get_mpu(mpu)
+            self.mpu_type = self._get_mpu(mpu)
 
         if load is not None:
             cmd = "load %s" % load

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -105,8 +105,7 @@ class Monitor(cmd.Cmd):
                 msg = "Fatal: no such MPU. Available MPUs: %s"
                 self._output(msg % ', '.join(mpus))
                 sys.exit(1)
-            cmd = "mpu %s" % mpu
-            self.onecmd(cmd)
+             self.mpu_type = self._get_mpu(mpu)
 
         if load is not None:
             cmd = "load %s" % load


### PR DESCRIPTION
As reported by mail: setting the mpu on the command line would cause it to be set and then immediately reset to 6502.