### PR TITLE
Proposed fix for #47 Save and restore termios settings with helper functions in utils.console

### DIFF
--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -480,9 +480,9 @@ class Monitor(cmd.Cmd):
             newattr = self.oldattr[:]
             newattr[3] &= ~termios.ICANON & ~termios.ECHO
 
-            # Switch to non-blocking reads.
+            # Switch to non-blocking reads with 0.1 second timeout.
             newattr[6][termios.VMIN] = 0
-            newattr[6][termios.VTIME] = 0
+            newattr[6][termios.VTIME] = 1
             termios.tcsetattr(fd, termios.TCSANOW, newattr)
 
 

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -135,7 +135,6 @@ class Monitor(cmd.Cmd):
             result = cmd.Cmd.onecmd(self, line)
         except KeyboardInterrupt:
             self._output("Interrupt")
-
         except Exception:
             (file, fun, line), t, v, tbinfo = compact_traceback()
             error = 'Error: %s, %s: file: %s line: %s' % (t, v, file, line)
@@ -497,7 +496,6 @@ class Monitor(cmd.Cmd):
 
         # Switch back to the previous input mode.
         console.restore_mode(self.stdin)    
-
 
     def help_radix(self):
         self._output("radix [H|D|O|B]")

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -55,6 +55,8 @@ class Monitor(cmd.Cmd):
         self._add_shortcuts()
         cmd.Cmd.__init__(self, stdin=stdin, stdout=stdout)
 
+        console.save_mode(self.stdin)
+
         if argv is None:
             argv = sys.argv
         load, rom, goto = self._parse_args(argv)
@@ -131,6 +133,7 @@ class Monitor(cmd.Cmd):
             result = cmd.Cmd.onecmd(self, line)
         except KeyboardInterrupt:
             self._output("Interrupt")
+
         except Exception:
             (file, fun, line), t, v, tbinfo = compact_traceback()
             error = 'Error: %s, %s: file: %s line: %s' % (t, v, file, line)
@@ -138,6 +141,9 @@ class Monitor(cmd.Cmd):
 
         if not line.startswith("quit"):
             self._output_mpu_status()
+
+        # Switch back to the previous input mode.
+        console.restore_mode(self.stdin)    
 
         return result
 
@@ -885,6 +891,7 @@ def main(args=None):
         c.cmdloop()
     except KeyboardInterrupt:
         c._output('')
+        console.restore_mode(c.stdin)
 
 if __name__ == "__main__":
     main()

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -55,6 +55,8 @@ class Monitor(cmd.Cmd):
         self._add_shortcuts()
         cmd.Cmd.__init__(self, stdin=stdin, stdout=stdout)
 
+        # Save the current input mode so it can be restored after
+        # after processing commands and before exiting.
         console.save_mode(self.stdin)
 
         if argv is None:

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -54,31 +54,13 @@ class Monitor(cmd.Cmd):
         self.prompt = "."
         self._add_shortcuts()
 
-        # Attempt to get a copy of stdin that is unbuffered.
-        # This allows for immediate response to typed input as well as
-        # pasted input.  If unable to get an unbuffered version of
-        # stdin, use the original version.
-        if stdin != None:
-            try:
-                # Reopen stdin with no buffer.
-                self.unbuffered_stdin = os.fdopen(stdin.fileno(), 'rb', 0)
-            except Exception as e:
-                print(e)
-                # Unable to reopen this file handle with no buffer.
-                # Just use the original file handle.
-                print("Error opening unbuffered stdin - using buffered version")
-                self.unbuffered_stdin = stdin
-        else:
-            # If stdin is None, try using sys.stdin for input.
-            try:
-                # Reopen the system's stdin with no buffer.
-                self.unbuffered_stdin = os.fdopen(sys.stdin.fileno(), 'rb', 0)
-            except Exception as e:
-                print(e)
-                print("Error opening default unbuffered stdin - using buffered version")
-                self.unbuffered_stdin = None
+        # Attempt to get a copy of stdin that is unbuffered on systems
+        # that support it.  This allows for immediate response to
+        # typed input as well as pasted input.  If unable to get an
+        # unbuffered version of stdin, the original version is returned.
+        stdin = console.get_unbuffered_stdin(stdin)
 
-        cmd.Cmd.__init__(self, stdin=self.unbuffered_stdin, stdout=stdout)
+        cmd.Cmd.__init__(self, stdin=stdin, stdout=stdout)
 
         # Save the current input mode so it can be restored after
         # after processing commands and before exiting.

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -59,7 +59,7 @@ class Monitor(cmd.Cmd):
         # after processing commands and before exiting.
         console.save_mode(self.stdin)
 
-        # Check for any exceptions thrown during __init__ while\
+        # Check for any exceptions thrown during __init__ while
         # processing the arguments.
         try:
 
@@ -81,7 +81,7 @@ class Monitor(cmd.Cmd):
                 physMask = self._mpu.memory.physMask
                 reset = self._mpu.RESET & physMask
                 dest = self._mpu.memory[reset] + \
-                       (self._mpu.memory[reset + 1] << self.byteWidth)
+                    (self._mpu.memory[reset + 1] << self.byteWidth)
                 self.do_goto("$%x" % dest)
         except:
             # Restore input mode on any exception and then rethrow the

--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -36,10 +36,7 @@ if sys.platform[:3] == "win":
         return ''
 
 else:
-    import select
-    import os
     import termios
-    import fcntl
 
     oldattr = None
 

--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -187,8 +187,9 @@ else:
         except:
             pass
 
-        if char == "\n":
-            char = "\r"
+        # Convert linefeeds to carriage returns.
+        if char != '' and ord(char) == 10:
+            char = '\r'
         return char
 
 

--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -60,7 +60,6 @@ else:
         except:
             # Quietly ignore termios errors, such as stdin not being
             # a tty.
-            print("DEBUG: Exception getting termios settings")
             pass
 
     def noncanonical_mode(stdin):
@@ -115,9 +114,15 @@ else:
         noncanonical_mode(stdin)
         # If we didn't get a character, ask again.
         while char == '':
-            char = stdin.read(1)
-            # stdin has already been set up with a 0.1s delay, so we
-            # don't need an additional delay here.
+            try:
+                char = stdin.read(1)
+                # stdin has already been set up with a 0.1s delay, so we
+                # don't need an additional delay here.
+            except KeyboardInterrupt:
+                # Pass along a CTRL-C interrupt.
+                raise
+            except:
+                pass
         return char
 
     def getch_noblock(stdin):
@@ -128,7 +133,13 @@ else:
 
         # Using non-blocking read
         noncanonical_mode(stdin)
-        char = stdin.read(1)
+        try:
+            char = stdin.read(1)
+        except KeyboardInterrupt:
+            # Pass along a CTRL-C interrupt.
+            raise
+        except:
+            pass
 
         if char == "\n":
             char = "\r"

--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -35,10 +35,8 @@ else:
         Does not echo the character.
         """
         # Try to get a character with a non-blocking read.
-        char = stdin.read(1)
+        char = ''
         while char == '':
-            # If we don't get one right away, wait a bit and try again.
-            time.sleep(0.001)
             char = stdin.read(1)
         return char
 
@@ -49,9 +47,7 @@ else:
         char = ''
         # Using non-blocking read as set up in Monitor._run
         char = stdin.read(1)
-        if char == '':
-            # Don't use 100% CPU while waiting for input.
-            time.sleep(0.001)
+
         if char == "\n":
             char = "\r"
         return char

--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -1,9 +1,6 @@
 import sys
 import time
 
-
-
-
 if sys.platform[:3] == "win":
     import msvcrt
 
@@ -49,7 +46,7 @@ else:
         mode.  In this mode, characters are given immediately to the
         program and no processing of editing characters (like backspace)
         is performed.  Echo is also turned off in this mode.  The
-        previous input behavior can be restored with 
+        previous input behavior can be restored with restore_mode.
         """
         # For non-windows systems, switch to non-canonical
         # and no-echo non-blocking-read mode.
@@ -72,9 +69,7 @@ else:
 
     def restore_mode(stdin):
         """For operating systems that support it, restore the previous 
-        input mode.  In this mode, a line can be entered and edited 
-        until Enter is pressed, and then the line is passed to the 
-        program for processing.
+        input mode.
         """
 
         # Restore the previous input setup.

--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -1,11 +1,10 @@
 import sys
-import time
 
 if sys.platform[:3] == "win":
     import msvcrt
 
     def save_mode(stdin):
-        """ get_mode is a no-op on Windows. """
+        """ save_mode is a no-op on Windows. """
         return
 
     def noncanonical_mode(stdin):

--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -80,9 +80,9 @@ else:
             newattr = currentattr[:]
             newattr[3] &= ~termios.ICANON & ~termios.ECHO
 
-            # Switch to non-blocking reads with 0.1 second timeout.
+            # Switch to non-blocking reads with no timeout.
             newattr[6][termios.VMIN] = 0
-            newattr[6][termios.VTIME] = 1
+            newattr[6][termios.VTIME] = 0
             termios.tcsetattr(fd, termios.TCSANOW, newattr)
         except:
             # Quietly ignore termios errors, such as stdin not being


### PR DESCRIPTION
After playing around with this for a while, I believe the best location to change the termios settings for linux (should also work for other posix environments like OSX and cygwin, but I can't test that as I only have Linux) is in Monitor._run.  It's only when the 65C02 software is actually being run that we want non-echoed input.  I also changed the method of getting non-blocking reads to the standard method used when using termios (rather than using fcntl), which is to set the minimum number of characters to zero.  I also set the time to wait for a character to 1/10th of a second (the minimum time available using termios) to stop it from using 100% CPU while waiting for a character.  This is the same amount of time that was being used by the original select() method.  Like select(), it will return immediately if data is available before the timeout.

With this change, I can now paste large input into py65mon's terminal window and it will all be passed to the software running inside py65mon.  If CTRL-C is used to get back to the monitor, the normal input is restored.

I don't believe this will change mlauke's issue #46, except that it might move the error to monitor.py instead.  I was not able to reproduce that error at all, so I can't say for sure.