### PR TITLE
Add string formatting to load option for Windows backslashes in paths

### DIFF
--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -62,7 +62,7 @@ class Monitor(cmd.Cmd):
         self._reset(self.mpu_type, self.getc_addr, self.putc_addr)
 
         if load is not None:
-            self.do_load(load)
+            self.do_load("%r" % load)
 
         if goto is not None:
             self.do_goto(goto)


### PR DESCRIPTION
Fix for #49.
The -r option uses % style string formatting and works fine, so I just added that to the -l option.  The % formatting seems to properly pass along the backslashes in a windows path instead of seeing them as escaping characters.