### PR TITLE
Added `go` command, help, tests (Issue 51)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "env\\Scripts\\python.exe"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "env\\Scripts\\python.exe"
+}

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -168,6 +168,7 @@ class Monitor(cmd.Cmd):
                            'f':    'fill',
                            '>':    'fill',
                            'g':    'goto',
+                           'go':   'go',
                            'h':    'help',
                            '?':    'help',
                            'l':    'load',
@@ -458,6 +459,14 @@ class Monitor(cmd.Cmd):
             return self.help_goto()
 
         self._mpu.pc = self._address_parser.number(args)
+        brks = [0x00]  # BRK
+        self._run(stopcodes=brks)
+    
+    def help_go(self):
+        self._output("go")
+        self._output("Continue execution.")
+        
+    def do_go(self, args):
         brks = [0x00]  # BRK
         self._run(stopcodes=brks)
 

--- a/py65/tests/test_monitor.py
+++ b/py65/tests/test_monitor.py
@@ -517,6 +517,46 @@ class MonitorTests(unittest.TestCase):
         mon.do_goto('0')
         self.assertEqual(0x02, mon._mpu.pc)
 
+    # go
+
+    def test_shortcut_for_go(self):
+        stdout = StringIO()
+        mon = Monitor(stdout=stdout)
+        mon.do_help('go')
+
+        out = stdout.getvalue()
+        self.assertTrue(out.startswith('go'))
+
+    def test_go_with_breakpoints_stops_execution_at_breakpoint(self):
+        stdout = StringIO()
+        mon = Monitor(stdout=stdout)
+        mon._breakpoints = [ 0x03 ]
+        mon._mpu.memory = [ 0xEA, 0xEA, 0xEA, 0xEA ]
+        mon._mpu.pc = 0x00
+        mon.do_go('')
+        out = stdout.getvalue()
+        self.assertTrue(out.startswith("Breakpoint 0 reached"))
+        self.assertEqual(0x03, mon._mpu.pc)
+
+    def test_go_with_breakpoints_stops_execution_at_brk(self):
+        stdout = StringIO()
+        mon = Monitor(stdout=stdout)
+        mon._breakpoints = [ 0x02 ]
+        mon._mpu.memory = [ 0xEA, 0xEA, 0x00, 0xEA ]
+        mon._mpu.pc = 0x00
+        mon.do_go('')
+        self.assertEqual(0x02, mon._mpu.pc)
+
+    def test_go_without_breakpoints_stops_execution_at_brk(self):
+        stdout = StringIO()
+        mon = Monitor(stdout=stdout)
+        mon._breakpoints = []
+        mon._mpu.memory = [ 0xEA, 0xEA, 0x00, 0xEA ]
+        mon._mpu.pc = 0x00
+        mon.do_go('')
+        self.assertEqual(0x02, mon._mpu.pc)
+
+
     # help
 
     def test_help_without_args_shows_documented_commands(self):


### PR DESCRIPTION
Added support for `go` command to continue execution at the current PC, help for `go`, and tests
Addresses Issue 51: Feature Request: a "continue" command