### PR TITLE
docs/index.rst: Fix URL for VICE

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,10 +33,10 @@ The monitor is started using the ``py65mon`` command::
 Once the monitor has started, it will display a register dump and the
 dot prompt.  You can then enter commands for the monitor at this prompt.
 
-Py65Mon uses commands that are very similar to those used by the monitor
-included with the `VICE emulator <http://viceteam.org>`_ for Commodore
-computers.  You can get a list of available commands with ``help`` or
-help on a specific command with ``help command``.
+Py65Mon uses commands that are very similar to those used by the
+`VICE emulator's monitor <http://vice-emu.sourceforge.net/vice_12.html>`_
+for Commodore computers.  You can get a list of available commands
+with ``help`` or help on a specific command with ``help command``.
 
 Number Systems
 --------------


### PR DESCRIPTION
The viceteam.org domain was lost to a domain squatter in
2014[[1]], and is now the site of a law firm. The curent site
is vice-emu.sourceforge.net.

Also, we deep link directly into the VICE monitor documentation,
since that's likely what people will want to see when following
this link. It's easy from there to get back to the top page (just
delete `vice_12.html` in the URL bar) if that's what the user wants.

[1]: https://web.archive.org/web/20140601000000*/viceteam.org