### PR TITLE
Added irq() and nmi() to the MPU

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,10 @@
    Py65 now requires Python 3.4 or later.  On Python 2, Py65 now requires
    Python 2.7.
 
+ - added ``irq()`` and ``nmi()`` methods to the ``MPU`` class, so that
+   interrupts can be simulated. Patch by Irmen de Jong.
+
+
 1.1.0 (2018-07-01)
 ------------------
 

--- a/py65/devices/mpu6502.py
+++ b/py65/devices/mpu6502.py
@@ -74,6 +74,28 @@ class MPU:
         self.p = self.BREAK | self.UNUSED
         self.processorCycles = 0
 
+    def irq(self):
+        # triggers a normal IRQ
+        # this is very similar to the BRK instruction
+        if self.p & self.INTERRUPT:
+            return
+        self.stPushWord(self.pc)
+        self.p &= ~self.BREAK
+        self.stPush(self.p | self.UNUSED)
+        self.p |= self.INTERRUPT
+        self.pc = self.WordAt(self.IRQ)
+        self.processorCycles += 7
+
+    def nmi(self):
+        # triggers a NMI IRQ in the processor
+        # this is very similar to the BRK instruction
+        self.stPushWord(self.pc)
+        self.p &= ~self.BREAK
+        self.stPush(self.p | self.UNUSED)
+        self.p |= self.INTERRUPT
+        self.pc = self.WordAt(self.NMI)
+        self.processorCycles += 7
+
     # Helpers for addressing modes
 
     def ByteAt(self, addr):


### PR DESCRIPTION
For my Python Commodore-64 emulator (pyc64) I require the ability to interrupt the CPU during execution.   I can create these functions myself but I think they're better suited on the MPU class itself.  Notice that the implementation of both is very similar to the BRK instruction

(side note: the emulator now runs the 'real' c64 ROMs and boots up a working basic environment, and runs at slightly over half the speed of a real c64 with regular cpython. Quite astonishing for an interpreted language. Running it with pypy is where it gets really interesting)