### PR TITLE
correct byte-vs-string issue in line_input

### DIFF
--- a/py65/utils/console.py
+++ b/py65/utils/console.py
@@ -25,8 +25,7 @@ if sys.platform[:3] == "win":
         for function signature compatibility and is ignored.
         """
         c = msvcrt.getch()
-        if isinstance(c, bytes): # Python 3
-            c = c.decode('latin-1')
+        return c.decode('latin-1') if isinstance(c, bytes) else c
         return c
 
     def getch_noblock(stdin):
@@ -163,7 +162,7 @@ else:
                 raise
             except:
                 pass
-        return char
+        return char.decode() if isinstance(char, bytes) else char
 
     def getch_noblock(stdin):
         """ Read one character from stdin without blocking.  Does not echo the
@@ -190,7 +189,7 @@ else:
         # Convert linefeeds to carriage returns.
         if len(char) and ord(char) == 10:
             char = '\r'
-        return char
+        return char.decode() if isinstance(char, bytes) else char
 
 
 def line_input(prompt='', stdin=sys.stdin, stdout=sys.stdout):


### PR DESCRIPTION
Ensure that getch() returns a unicode string rather than
a byte string.

closes #266