### PR TITLE
Several enhancements: (b)atch and (c)continue commands; relative address ranges, ascii dump option; compact mpu status; doc updates

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,6 +151,13 @@ and then delete breakpoint #1, the next breakpoint you add will be
 breakpoint #3, not #1.  Also, invoking ``reset`` clears breakpoints
 too, not just labels.
 
+Comments
+-----------
+
+Any text following a `;` will be treated as a comment and removed.
+This can be useful for documenting sequences of commands used for `script`.
+
+
 Command Reference
 =================
 
@@ -215,6 +222,12 @@ Command Reference
 
     .cycles
     12
+
+.. describe:: continue
+
+  Continue execution from the current program counter::
+
+    .continue
 
 .. describe:: delete_breakpoint <breakpoint_id>
 
@@ -303,6 +316,14 @@ Command Reference
     Breakpoint 0 : $1234
     Breakpoint 1 : $5678
     Breakpoint 2 : $9ABC
+
+.. describe:: input <filename>
+
+  Read commands from <filename> as if typed interactively,
+  except that blank lines are ignored rather than repeating the prior command.
+  As usual, text beginning with ; will be treated as a comment and ignored
+
+    .input some.cmd
 
 .. describe:: load <filename> <address>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -317,13 +317,13 @@ Command Reference
     Breakpoint 1 : $5678
     Breakpoint 2 : $9ABC
 
-.. describe:: input <filename>
+.. describe:: batch <filename>
 
   Read commands from <filename> as if typed interactively,
   except that blank lines are ignored rather than repeating the prior command.
   As usual, text beginning with ; will be treated as a comment and ignored
 
-    .input some.cmd
+    .batch some.cmd
 
 .. describe:: load <filename> <address>
 

--- a/py65/devices/mpu6502.py
+++ b/py65/devices/mpu6502.py
@@ -50,10 +50,14 @@ class MPU:
 
     def __repr__(self):
         flags = itoa(self.p, 2).rjust(self.BYTE_WIDTH, '0')
-        indent = ' ' * (len(self.name) + 2)
+        #indent = ' ' * (len(self.name) + 2)
+        pairs = [''.join(t) for t in zip('NV-BDIZC', flags) if t[0] != '-']
+        return "%s: PC=%04x A=%02x X=%02x Y=%02x SP=%02x FLAGS=<%s>" % (
+            self.name, self.pc, self.a, self.x, self.y, self.sp, ' '.join(pairs)
+        )
 
-        return self.reprformat() % (indent, self.name, self.pc, self.a,
-                                    self.x, self.y, self.sp, flags)
+        #return self.reprformat() % (indent, self.name, self.pc, self.a,
+        #                            self.x, self.y, self.sp, flags)
 
     def step(self):
         instructCode = self.memory[self.pc]

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -435,16 +435,11 @@ class Monitor(cmd.Cmd):
                 self.stdout.write("\r$%s  ?Syntax\n" % addr)
 
     def do_disassemble(self, args):
-        splitted = shlex.split(args)
-        if len(splitted) != 1:
+        split = shlex.split(args)
+        if len(split) != 1:
             return self.help_disassemble()
 
-        address_parts = splitted[0].split(":")
-        start = self._address_parser.number(address_parts[0])
-        if len(address_parts) > 1:
-            end = self._address_parser.number(address_parts[1])
-        else:
-            end = start
+        start, end = self._address_parser.range(split[0], self._mpu.pc, False)
 
         max_address = (2 ** self._mpu.ADDR_WIDTH) - 1
         cur_address = start
@@ -784,7 +779,7 @@ class Monitor(cmd.Cmd):
             return self.help_fill()
 
         try:
-            start, end = self._address_parser.range(split[0])
+            start, end = self._address_parser.range(split[0], self._mpu.pc)
             filler = []
             for piece in split[1:]:
                 value = self._address_parser.number(piece)
@@ -831,7 +826,7 @@ class Monitor(cmd.Cmd):
         if len(split) != 1:
             return self.help_mem()
 
-        start, end = self._address_parser.range(split[0])
+        start, end = self._address_parser.range(split[0], self._mpu.pc)
 
         line = self.addrFmt % start + ":"
         chrs = ''

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -453,6 +453,7 @@ class Monitor(cmd.Cmd):
                 if start > end and cur_address > max_address:
                     needs_wrap = False
                     cur_address = 0
+        self._address_parser.next_addr = cur_address
 
     def _format_disassembly(self, address, length, disasm):
         cur_address = address
@@ -731,6 +732,7 @@ class Monitor(cmd.Cmd):
                     return (msb << 8) + lsb
             bytes = list(map(format, bytes[0::2], bytes[1::2]))
 
+        self._address_parser.next_addr = start
         self._fill(start, start, bytes)
 
     def help_save(self):

--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -170,7 +170,8 @@ class Monitor(cmd.Cmd):
         self._output(usage)
 
     def onecmd(self, line):
-        line = self._preprocess_line(line)
+        if line:
+            line = self._preprocess_line(line)
 
         result = None
         try:
@@ -181,7 +182,7 @@ class Monitor(cmd.Cmd):
             error = ''.join(traceback.format_exception(e))
             self._output(error)
 
-        if not line.startswith("quit"):
+        if line and not line.startswith("quit"):
             self._output_mpu_status()
 
         # Switch back to the previous input mode.

--- a/py65/utils/addressing.py
+++ b/py65/utils/addressing.py
@@ -13,7 +13,7 @@ class AddressParser(object):
         """
         self.radix = radix
         self.maxwidth = maxwidth
-
+        self._default_start = 0
         self.labels = {}
         for k, v in labels.items():
             self.labels[k] = self._constrain(v)
@@ -84,7 +84,7 @@ class AddressParser(object):
         except ValueError:
             raise KeyError("Label not found: %s" % num)
 
-    def range(self, addresses, default_start=0, no_wrap=True):
+    def range(self, addresses, no_wrap=True):
         """
         Parse a string containing an address or a range of addresses
         into a tuple of (start address, end address).
@@ -95,7 +95,7 @@ class AddressParser(object):
         """
         # split and keep delim, e.g. 123+456 => ['123', '+', '456']
         parts = re.split(r'([:,/])', addresses.strip())
-        start = self.number(parts[0]) if parts[0] else default_start
+        start = self.number(parts[0]) if parts[0] else self._default_start
         if len(parts) >= 3:
             v = self.number(parts[2])
             end = start + max(0, v-1) if parts[1] == '/' else v
@@ -104,6 +104,7 @@ class AddressParser(object):
 
         if no_wrap and start > end:
             start, end = end, start
+        self._default_start = (end + 1) % self._maxaddr
         return (start, end)
 
     def _constrain(self, address):

--- a/py65/utils/addressing.py
+++ b/py65/utils/addressing.py
@@ -84,17 +84,25 @@ class AddressParser(object):
         except ValueError:
             raise KeyError("Label not found: %s" % num)
 
-    def range(self, addresses):
-        """Parse a string containing an address or a range of addresses
-        into a tuple of (start address, end address)
+    def range(self, addresses, default_start=0, no_wrap=True):
         """
-        matches = re.match('^([^:,]+)\s*[:,]+\s*([^:,]+)$', addresses)
-        if matches:
-            start, end = map(self.number, matches.groups(0))
+        Parse a string containing an address or a range of addresses
+        into a tuple of (start address, end address).
+        Start should be an address, label or empty implying default, e.g. _mpu.pc
+        A singleton implies a single byte.
+        A range specified with : or , extends to the end address or label
+        A range specified with / interprets end as an offset from start
+        """
+        # split and keep delim, e.g. 123+456 => ['123', '+', '456']
+        parts = re.split(r'([:,/])', addresses.strip())
+        start = self.number(parts[0]) if parts[0] else default_start
+        if len(parts) >= 3:
+            v = self.number(parts[2])
+            end = start + max(0, v-1) if parts[1] == '/' else v
         else:
-            start = end = self.number(addresses)
+            end = start
 
-        if start > end:
+        if no_wrap and start > end:
             start, end = end, start
         return (start, end)
 

--- a/py65/utils/addressing.py
+++ b/py65/utils/addressing.py
@@ -13,7 +13,7 @@ class AddressParser(object):
         """
         self.radix = radix
         self.maxwidth = maxwidth
-        self._default_start = 0
+        self.next_addr = 0
         self.labels = {}
         for k, v in labels.items():
             self.labels[k] = self._constrain(v)
@@ -95,7 +95,7 @@ class AddressParser(object):
         """
         # split and keep delim, e.g. 123+456 => ['123', '+', '456']
         parts = re.split(r'([:,/])', addresses.strip())
-        start = self.number(parts[0]) if parts[0] else self._default_start
+        start = self.number(parts[0]) if parts[0] else self.next_addr
         if len(parts) >= 3:
             v = self.number(parts[2])
             end = start + max(0, v-1) if parts[1] == '/' else v
@@ -104,7 +104,7 @@ class AddressParser(object):
 
         if no_wrap and start > end:
             start, end = end, start
-        self._default_start = (end + 1) % self._maxaddr
+        self.next_addr = (end + 1) % self._maxaddr
         return (start, end)
 
     def _constrain(self, address):


### PR DESCRIPTION
py65 has been super useful while taking apart an old atari game (see work in progress https://github.com/patricksurry/eastern-front-1941/)

This PR collects a number of small extensions and improvements I made to `py65` as I went along:

- `(b)atch` command: I had a bunch of setup commands for labels etc that I repeated on each launch.  I initially did `cat setup.cmd - | py65` which sort of works but it doesn't echo the input lines making the input confusing.   The batch command and command-line option reads a file to the existing `cmd.cmdqueue` buffer and tracks whether to echo each command as it's executed, as if typed interactively.

- `(c)ontinue`: to continue from current PC to next breakpoint, also suggested  in https://github.com/mnaberez/py65/issues/51   I prefer `continue` to `go` based on other debuggers and `go` feeling too close to `goto`.  Another option would be to support `goto` without an address

- support for implied and relative address ranges.  Omitting the start address in a range continues from the end of the last address range.  Writing a range with a `/` separator interprets the second value as a length rather than an absolute address.   This works for `disassemble`, `fill` and `mem` making it easier to step through chunks of code/memory.   Hitting enter to repeat a last command like `d /20` will disassemble the next 20 bytes (aligning to the end of the last instruction).

```
.m 2100:2120
2100:  a9  00  85  82  a9  04  85  83  a9  00  85  84  a9  06  85  85  a9  1c
2112:  85  80  a9  21  85  81  4c  23  20  00  14  22  03  00  af

6502: PC=0000 A=00 X=00 Y=00 SP=ff FLAGS=<N0 V0 B1 D0 I0 Z0 C0>
.m :2140
2121:  22  1b  21  00  00  04  45  58  49  54  2d  21  38  a5  84  e9  02  85
2133:  84  b0  02  c6  85  a0  00  b1  84  85  80  c8  b1  84

6502: PC=0000 A=00 X=00 Y=00 SP=ff FLAGS=<N0 V0 B1 D0 I0 Z0 C0>
.m 2140/20
2140:  84  85  81  4c  23  20  24  21  04  44  52  4f  50  4f  21  38  a5  82
2152:  e9  02  85  82  b0  02  c6  83  4c  23  20  46  21  04

6502: PC=0000 A=00 X=00 Y=00 SP=ff FLAGS=<N0 V0 B1 D0 I0 Z0 C0>
.m /20
2160:  53  57  41  50  66  21  38  a5  82  e9  02  85  82  b0  02  c6  83  a0
2172:  00  b1  82  85  86  c8  b1  82  85  87  38  a5  82  e9

6502: PC=0000 A=00 X=00 Y=00 SP=ff FLAGS=<N0 V0 B1 D0 I0 Z0 C0>
.
2180:  02  85  82  b0  02  c6  83  a0  00  b1  82  85  88  c8  b1  82  85  89
2192:  a0  00  a5  86  91  82  c8  a5  87  91  82  18  a5  82

6502: PC=0000 A=00 X=00 Y=00 SP=ff FLAGS=<N0 V0 B1 D0 I0 Z0 C0>
.
```
 
- optional `ascii|noascii` option for the `mem` command to append an ascii representation of each line.  This is useful for understanding string tables etc:

```
.m 2290:22c0 ascii
2290: 23 20 3a 22 06 44 4f 55 42 4c 45 00 20 c7 21 3e 22 2b  # :".DOUBLE. G!>"+
22a2: 21 92 22 09 51 55 41 44 52 55 50 4c 45 00 20 9b 22 9b  !.".QUADRUPLE. .".
22b4: 22 2b 21 a9 00 88 10 01 60 51 86 0a 69                 "+!)....`Q..i

6502: PC=0000 A=00 X=00 Y=00 SP=ff FLAGS=<N0 V0 B1 D0 I0 Z0 C0>
```

- updated doc including a note about `;`-style comments I discovered but hadn't seen written anywhere.

- as a personal preference I compacted the MPU summary from two lines to one which imho makes it much easier to compare changes as you step thru code.   This could also be a command-line switch I guess?  Here's the before and after:
```
       PC  AC XR YR SP NV-BDIZC
6502: 0000 00 00 00 ff 00110000

6502: PC=0000 A=00 X=00 Y=00 SP=ff FLAGS=<N0 V0 B1 D0 I0 Z0 C0>
```
