### PR TITLE
fixes issue 45 (repeating last command shows duplicate mpu status) 

### DIFF
--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -153,7 +153,8 @@ class Monitor(cmd.Cmd):
         self._output(usage)
 
     def onecmd(self, line):
-        line = self._preprocess_line(line)
+        if line:
+            line = self._preprocess_line(line)
 
         result = None
         try:
@@ -164,7 +165,7 @@ class Monitor(cmd.Cmd):
             error = ''.join(traceback.format_exception(e))
             self._output(error)
 
-        if not line.startswith("quit"):
+        if line and not line.startswith("quit"):
             self._output_mpu_status()
 
         # Switch back to the previous input mode.


### PR DESCRIPTION
Fix for https://github.com/mnaberez/py65/issues/45

With an empty line, onecmd ends up calling itself so we skip the status report on the initial call

```
py65mon

Py65 Monitor

       PC  AC XR YR SP NV-BDIZC
6502: 0000 00 00 00 ff 00110000
.m 0
0000:  00

       PC  AC XR YR SP NV-BDIZC
6502: 0000 00 00 00 ff 00110000
.
0000:  00

       PC  AC XR YR SP NV-BDIZC
6502: 0000 00 00 00 ff 00110000
.
```