### PR TITLE
Stop condition now checked on first instruction

### DIFF
--- a/py65/monitor.py
+++ b/py65/monitor.py
@@ -504,19 +504,22 @@ class Monitor(cmd.Cmd):
 
         if not breakpoints:
             while True:
-                mpu.step()
                 if mem[mpu.pc] in stopcodes:
+                    mpu.step()
                     break
+                mpu.step()
         else:
             while True:
-                mpu.step()
                 pc = mpu.pc
                 if mem[pc] in stopcodes:
+                    mpu.step()
                     break
                 if pc in breakpoints:
                     msg = "Breakpoint %d reached."
                     self._output(msg % self._breakpoints.index(pc))
+                    mpu.step()
                     break
+                mpu.step()
 
         # Switch back to the previous input mode.
         console.restore_mode()


### PR DESCRIPTION
When setting two breakpoints in a row, the second one would be skipped. Now, each one is run after another.